### PR TITLE
Generate sitemap only for enabled languages

### DIFF
--- a/application/controller/SitemapController.php
+++ b/application/controller/SitemapController.php
@@ -34,7 +34,7 @@ class SitemapController extends FrontendController
 
 	public function index()
 	{
-		$languages = $this->application->getLanguageArray(true);
+		$languages = $this->application->getLanguageArray(true, false);   // only enabled languages
 		$defaultLanguage = $this->application->getDefaultLanguageCode();
 
 		$maps = array();


### PR DESCRIPTION
In previous versions also disabled languages are included in the sitemap. Corrected here.
